### PR TITLE
Add emeyer and lknitter user profiles

### DIFF
--- a/PITPARSE
+++ b/PITPARSE
@@ -37,6 +37,24 @@ USER_PROFILES <- list(
     junk_path    = "C:/users/chaskell/DOI/MCFWCO Yakima Sub-Office - Documents/General/TagLists/Test Tags and Pingers.txt",
     antenna_log  = "C:/users/chaskell/DOI/MCFWCO Yakima Sub-Office - Documents/General/Antenna Data/Antenna Log.xlsx",
     initials     = ""
+  ),
+  emeyer = list(
+    download_dir = "C:/users/emeyer/DOI/MCFWCO Yakima Sub-Office - Documents/General/Antenna Data/Non_TNWR_Antenna_Files/Download Files",
+    taglist_dir  = "C:/users/emeyer/DOI/MCFWCO Yakima Sub-Office - Documents/General/TagLists",
+    compiled_dir = "C:/users/emeyer/DOI/MCFWCO Yakima Sub-Office - Documents/General/Antenna Data/Non_TNWR_Antenna_Files/Compiled Data",
+    vt_path      = "C:/users/emeyer/DOI/MCFWCO Yakima Sub-Office - Documents/General/TagLists/Virtual Test Tags.txt",
+    junk_path    = "C:/users/emeyer/DOI/MCFWCO Yakima Sub-Office - Documents/General/TagLists/Test Tags and Pingers.txt",
+    antenna_log  = "C:/users/emeyer/DOI/MCFWCO Yakima Sub-Office - Documents/General/Antenna Data/Antenna Log.xlsx",
+    initials     = ""
+  ),
+  lknitter = list(
+    download_dir = "C:/users/lknitter/DOI/MCFWCO Yakima Sub-Office - Documents/General/Antenna Data/Non_TNWR_Antenna_Files/Download Files",
+    taglist_dir  = "C:/users/lknitter/DOI/MCFWCO Yakima Sub-Office - Documents/General/TagLists",
+    compiled_dir = "C:/users/lknitter/DOI/MCFWCO Yakima Sub-Office - Documents/General/Antenna Data/Non_TNWR_Antenna_Files/Compiled Data",
+    vt_path      = "C:/users/lknitter/DOI/MCFWCO Yakima Sub-Office - Documents/General/TagLists/Virtual Test Tags.txt",
+    junk_path    = "C:/users/lknitter/DOI/MCFWCO Yakima Sub-Office - Documents/General/TagLists/Test Tags and Pingers.txt",
+    antenna_log  = "C:/users/lknitter/DOI/MCFWCO Yakima Sub-Office - Documents/General/Antenna Data/Antenna Log.xlsx",
+    initials     = ""
   )
 )
 


### PR DESCRIPTION
## Summary
- add user profiles for emeyer and lknitter with default paths

## Testing
- `R -q -e "parse(file='PITPARSE')"` *(fails: command not found: R)*
- `apt-get update` *(fails: repository ... is not signed; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b0aaaa2ee083209e4be64e4802f59f